### PR TITLE
Hotfix: Add Windows PowerShell compatibility to CI/CD workflows

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -182,6 +182,7 @@ jobs:
           echo "✅ Core packages built successfully"
 
       - name: Rebuild native modules for Electron
+        shell: bash
         run: |
           echo "Rebuilding native modules for Electron compatibility..."
           # Try the electron rebuild script first
@@ -203,6 +204,7 @@ jobs:
           echo "✅ Electron components built successfully"
           
       - name: Validate Electron build artifacts
+        shell: bash
         run: |
           echo "Validating Electron build artifacts..."
           


### PR DESCRIPTION
## 🔧 Critical Hotfix

This PR addresses a **Windows CI/CD build failure** that wasn't included in the previous v1.1.0 merge.

### **Issue Fixed:**
```
ParserError: Missing '(' after 'if' in if statement.
if npm run electron:rebuild; then
```

### **Root Cause:**
The GitHub Actions workflow was using bash shell syntax (`if command; then`) in Windows PowerShell environment, which doesn't understand this syntax.

### **Solution Applied:**
- Added explicit `shell: bash` directive to steps using bash-specific syntax
- Fixed native module rebuilding step in `.github/workflows/electron-release.yml`
- Fixed build artifacts validation step

### **Impact:**
- ✅ **Windows builds now work** alongside macOS and Linux in CI/CD
- ✅ **Cross-platform compatibility** ensured for all workflow steps
- ✅ **No breaking changes** - purely additive fix

### **Validation:**
This fix enables the electron-release workflow to run successfully on all platforms, ensuring:
- Native module rebuilding works on Windows
- Build artifact validation runs correctly
- Consistent bash shell environment across all platforms

**Priority: High** - This fix is needed for successful Windows builds in the release pipeline.